### PR TITLE
fixed bug

### DIFF
--- a/styles/abstracts/_constants.scss
+++ b/styles/abstracts/_constants.scss
@@ -1,7 +1,7 @@
 @use './colors' as *;
 
 $screen: (
-  mobile: 320px,
+  mobile: 480px,
   tablet: 768px,
   desktop: 1024px,
   wide: 1200px,


### PR DESCRIPTION
**Describe the bug**
Typography too big

**To Reproduce**
1. Go to mobile size lower than 480px

**Expected behavior**
- Change mobile size to 480px to adjust sizing

**Screenshots**
![image](https://user-images.githubusercontent.com/72827979/228376810-3f9976e0-610a-4eb0-b62e-a873fe727cf8.png)

